### PR TITLE
ci: GHA でのDockerビルドキャッシュの有効化

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,6 +22,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
@@ -45,5 +47,7 @@ jobs:
           labels: ${{ steps.metadata.outputs.labels }}
           file: apps/www/Dockerfile
           context: .
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           build-args: |
             CUSTOM_URL=${{ secrets.CUSTOM_URL }}


### PR DESCRIPTION
close #66 