### PR TITLE
fix(actions): use 'released' trigger to handle prerelease toggle

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -2,7 +2,7 @@ name: Deploy (production)
 
 on:
   release:
-    types: [published]
+    types: [released]
 
 concurrency:
   group: deploy-production


### PR DESCRIPTION
## Summary
- v3.0.0 を最初 prerelease で公開してからチェックを外したケースで Deploy (production) workflow が skip される事象を修正
- `release.published` は最初の publish 時にしか発火しないため prerelease=true で skip 後、後から外した時の `released` イベントを拾えていなかった
- `types: [released]` に変更すれば「prerelease を release に変えた」操作も拾える (こちらが今回のユースケースとして正しい)

## Test plan
- [ ] main マージ後、v3.0.0 release で prerelease を一度 ON にしてから OFF に戻す → workflow が起動 → デプロイ成功
- [ ] 以後、新規リリースを最初から非 prerelease で publish した場合も `released` で起動することを確認