### PR TITLE
feat(terraform): add shared account stack

### DIFF
--- a/.github/workflows/_check.yml
+++ b/.github/workflows/_check.yml
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        env: [development, production]
+        env: [development, production, shared]
     steps:
       - uses: actions/checkout@v6
 

--- a/terraform/environments/shared/.terraform.lock.hcl
+++ b/terraform/environments/shared/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.42.0"
+  constraints = "~> 6.40"
+  hashes = [
+    "h1:B00CO2gJ6fSyfUGhi+siRqNoUG9jI7PD+3r1dHWv3OI=",
+    "zh:0dd774a97eaa4371a60e13b5dc56800d4fb1c48d50e79049f75fc4fe26705ff5",
+    "zh:237d652d8ec028f7bedce1ce056ffe42e2e120d2a4a47fe45b97263cc5948e7e",
+    "zh:367d9e4b816e5f857956887b8f0770aaa5bec47c4b1e2c7bf924e39192d580d6",
+    "zh:4194addb5b34bb803fab031a80d84e9d16cac2308df9a498d51e2214c7893900",
+    "zh:5bcc36226fa5d8a3c37e41ac8cfd2b1eb73e7ae96f8418f6776dcaa16a987198",
+    "zh:61d0632d4cc7973b779b90c1d3bb2d05a1cd4d7030bb4645831e67cf735ecaa0",
+    "zh:7c7efaf9e4bb662ba3e8a714abafe7107bdcd1bf2cd0867510ea32762debc11d",
+    "zh:7d7f8ffe00d4a90184efa454a107bcc46d81f21245baea9678dcfa2fa77ac1be",
+    "zh:7e534c454cdeafe9cc225bea53397883bb96c54da6ea3421fd53dbc9dfc1bb90",
+    "zh:99564c99a0672b2a8b666ab2040f36a7c6f372fa79ac43a6657a54734e46fff8",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a6b1bb6178798882508f5512222a9433fc21e63cdae83a755650c938e6141d32",
+    "zh:a87592d6ff3d46ee83756f4f84503b2fe4ffc9c1d5dc9f8d4afccb5e126ae538",
+    "zh:daa56fb74c5c9d26b327c40b486beac71cdb9a932c7c4e4561f4401cd0d16a4a",
+    "zh:f35ab043d7121f3a194f42f5b0e0d59fe62d94488acea07e3783405fa5838785",
+  ]
+}

--- a/terraform/environments/shared/main.tf
+++ b/terraform/environments/shared/main.tf
@@ -1,0 +1,38 @@
+data "aws_iam_policy_document" "blog_prod_route53_writer_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${var.blog_prod_account_id}:root"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "blog_prod_route53_writer" {
+  statement {
+    actions = [
+      "route53:GetHostedZone",
+      "route53:ListResourceRecordSets",
+      "route53:ListTagsForResource",
+      "route53:ChangeResourceRecordSets",
+    ]
+    resources = ["arn:aws:route53:::hostedzone/${var.dns_zone_id}"]
+  }
+
+  statement {
+    actions   = ["route53:GetChange"]
+    resources = ["arn:aws:route53:::change/*"]
+  }
+}
+
+resource "aws_iam_role" "blog_prod_route53_writer" {
+  name               = "blog-prod-route53-writer"
+  assume_role_policy = data.aws_iam_policy_document.blog_prod_route53_writer_assume.json
+}
+
+resource "aws_iam_role_policy" "blog_prod_route53_writer" {
+  name   = "route53-write"
+  role   = aws_iam_role.blog_prod_route53_writer.id
+  policy = data.aws_iam_policy_document.blog_prod_route53_writer.json
+}

--- a/terraform/environments/shared/outputs.tf
+++ b/terraform/environments/shared/outputs.tf
@@ -1,0 +1,3 @@
+output "blog_prod_route53_writer_role_arn" {
+  value = aws_iam_role.blog_prod_route53_writer.arn
+}

--- a/terraform/environments/shared/providers.tf
+++ b/terraform/environments/shared/providers.tf
@@ -1,0 +1,10 @@
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      Environment = "shared"
+      ManagedBy   = "terraform"
+    }
+  }
+}

--- a/terraform/environments/shared/terraform.tfvars
+++ b/terraform/environments/shared/terraform.tfvars
@@ -1,0 +1,3 @@
+region               = "ap-northeast-1"
+blog_prod_account_id = "181791527365"
+dns_zone_id          = "Z04741573BLIJZ9ATP45N"

--- a/terraform/environments/shared/variables.tf
+++ b/terraform/environments/shared/variables.tf
@@ -1,0 +1,11 @@
+variable "region" {
+  type = string
+}
+
+variable "blog_prod_account_id" {
+  type = string
+}
+
+variable "dns_zone_id" {
+  type = string
+}

--- a/terraform/environments/shared/versions.tf
+++ b/terraform/environments/shared/versions.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = "~> 1.14"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.40"
+    }
+  }
+
+  backend "s3" {
+    bucket       = "tfstate-116584140838-ap-northeast-1-an"
+    key          = "blog/shared/terraform.tfstate"
+    region       = "ap-northeast-1"
+    encrypt      = true
+    use_lockfile = true
+  }
+}


### PR DESCRIPTION
## Summary
- 手動作成していた `blog-prod-route53-writer` IAM role (shared account) を Terraform で管理
- 既存リソースは `terraform import` で取り込み済み (apply は default_tags 追加のみ)
- state は `tfstate-116584140838-ap-northeast-1-an` の `blog/shared/terraform.tfstate` (project 名前空間で multi-tenant 対応)
- `_check.yml` の terraform-validate matrix に shared を追加

## Test plan
- [x] `terraform import` 成功
- [x] `terraform apply` で role を管理下に (default_tags 追加のみ)
- [x] CI で `Terraform Validate (shared)` がグリーンになる