### PR TITLE
feat(blog): add Google Analytics 4 tracking

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -39,6 +39,7 @@ jobs:
       - run: pnpm --filter blog build
         env:
           SITE_URL: ${{ vars.SITE_URL }}
+          PUBLIC_GA_MEASUREMENT_ID: ${{ vars.PUBLIC_GA_MEASUREMENT_ID }}
 
       - uses: aws-actions/configure-aws-credentials@v6
         with:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,5 @@
 pnpm-lock.yaml
 pnpm-workspace.yaml
+
+# Inline gtag stub uses `arguments`, which prettier-plugin-astro fails to parse.
+apps/blog/src/components/GoogleAnalytics.astro

--- a/apps/blog/.env.example
+++ b/apps/blog/.env.example
@@ -1,0 +1,3 @@
+# Google Analytics 4 Measurement ID (G-XXXXXXXXXX).
+# Used only in production builds (import.meta.env.PROD).
+PUBLIC_GA_MEASUREMENT_ID=

--- a/apps/blog/src/components/GoogleAnalytics.astro
+++ b/apps/blog/src/components/GoogleAnalytics.astro
@@ -1,0 +1,32 @@
+---
+const measurementId = import.meta.env.PUBLIC_GA_MEASUREMENT_ID;
+---
+
+{
+  measurementId && (
+    <>
+      <script
+        is:inline
+        async
+        src={`https://www.googletagmanager.com/gtag/js?id=${measurementId}`}
+      />
+      <script is:inline define:vars={{ measurementId }}>
+        window.dataLayer = window.dataLayer || [];
+        function gtag() {
+          dataLayer.push(arguments);
+        }
+        window.gtag = gtag;
+        gtag("js", new Date());
+        gtag("config", measurementId, { send_page_view: false });
+
+        document.addEventListener("astro:page-load", () => {
+          gtag("event", "page_view", {
+            page_path: location.pathname + location.search,
+            page_location: location.href,
+            page_title: document.title,
+          });
+        });
+      </script>
+    </>
+  )
+}

--- a/apps/blog/src/components/GoogleAnalytics.astro
+++ b/apps/blog/src/components/GoogleAnalytics.astro
@@ -1,21 +1,5 @@
 ---
 const measurementId = import.meta.env.PUBLIC_GA_MEASUREMENT_ID;
-
-const inlineScript = `
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  window.gtag = gtag;
-  gtag('js', new Date());
-  gtag('config', ${JSON.stringify(measurementId)}, { send_page_view: false });
-
-  document.addEventListener('astro:page-load', function () {
-    gtag('event', 'page_view', {
-      page_path: location.pathname + location.search,
-      page_location: location.href,
-      page_title: document.title,
-    });
-  });
-`;
 ---
 
 {
@@ -26,7 +10,21 @@ const inlineScript = `
         async
         src={`https://www.googletagmanager.com/gtag/js?id=${measurementId}`}
       />
-      <script is:inline set:html={inlineScript} />
+      <script is:inline define:vars={{ measurementId }}>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        window.gtag = gtag;
+        gtag("js", new Date());
+        gtag("config", measurementId, { send_page_view: false });
+
+        document.addEventListener("astro:page-load", () => {
+          gtag("event", "page_view", {
+            page_path: location.pathname + location.search,
+            page_location: location.href,
+            page_title: document.title,
+          });
+        });
+      </script>
     </>
   )
 }

--- a/apps/blog/src/components/GoogleAnalytics.astro
+++ b/apps/blog/src/components/GoogleAnalytics.astro
@@ -1,5 +1,21 @@
 ---
 const measurementId = import.meta.env.PUBLIC_GA_MEASUREMENT_ID;
+
+const inlineScript = `
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  window.gtag = gtag;
+  gtag('js', new Date());
+  gtag('config', ${JSON.stringify(measurementId)}, { send_page_view: false });
+
+  document.addEventListener('astro:page-load', function () {
+    gtag('event', 'page_view', {
+      page_path: location.pathname + location.search,
+      page_location: location.href,
+      page_title: document.title,
+    });
+  });
+`;
 ---
 
 {
@@ -10,23 +26,7 @@ const measurementId = import.meta.env.PUBLIC_GA_MEASUREMENT_ID;
         async
         src={`https://www.googletagmanager.com/gtag/js?id=${measurementId}`}
       />
-      <script is:inline define:vars={{ measurementId }}>
-        window.dataLayer = window.dataLayer || [];
-        function gtag() {
-          dataLayer.push(arguments);
-        }
-        window.gtag = gtag;
-        gtag("js", new Date());
-        gtag("config", measurementId, { send_page_view: false });
-
-        document.addEventListener("astro:page-load", () => {
-          gtag("event", "page_view", {
-            page_path: location.pathname + location.search,
-            page_location: location.href,
-            page_title: document.title,
-          });
-        });
-      </script>
+      <script is:inline set:html={inlineScript} />
     </>
   )
 }

--- a/apps/blog/src/layouts/Layout.astro
+++ b/apps/blog/src/layouts/Layout.astro
@@ -2,6 +2,7 @@
 import { Font } from "astro:assets";
 import { ClientRouter } from "astro:transitions";
 import type { Thing, WithContext } from "schema-dts";
+import GoogleAnalytics from "../components/GoogleAnalytics.astro";
 import Header from "../components/Header.astro";
 import JsonLd from "../components/JsonLd.astro";
 import {
@@ -82,6 +83,8 @@ const ogImageURL = new URL(ogImage, Astro.site).href;
     <meta name="twitter:creator" content={TWITTER_HANDLE} />
 
     {jsonLd.map((item) => <JsonLd data={item} />)}
+
+    <GoogleAnalytics />
   </head>
   <body class="px-4 pt-20">
     <Header />


### PR DESCRIPTION
## Summary

- Introduce a `GoogleAnalytics.astro` component that injects the GA4 (gtag.js) snippet only when `PUBLIC_GA_MEASUREMENT_ID` is set, so dev/local builds without the var stay untracked.
- Re-fire `page_view` on the `astro:page-load` event so SPA navigation under `ClientRouter` (View Transitions) is captured. Initial `gtag('config', ...)` is called with `send_page_view: false` to avoid duplicate hits.
- Wire `PUBLIC_GA_MEASUREMENT_ID` into the production deploy workflow only (development workflow stays untouched, keeping the dev environment uninstrumented).
- Add `apps/blog/.env.example` to document the variable for local setups.

## Follow-up (manual)

- Add `PUBLIC_GA_MEASUREMENT_ID = G-JHYNMVESYH` to the **Production** GitHub environment variables before merging the next release.
- After deploy, verify hits in GA4 → Realtime.

## Test plan

- [x] `PUBLIC_GA_MEASUREMENT_ID=G-... pnpm --filter blog build` — built HTML contains the gtag snippet
- [x] `pnpm --filter blog build` (no env var) — built HTML contains no GA references
- [ ] After deploy: confirm pageviews show up in GA4 Realtime, including SPA navigation between pages