### PR TITLE
feat(terraform): apex TXT を Terraform 管理化 (Search Console 認証)

### DIFF
--- a/terraform/environments/production/dns.tf
+++ b/terraform/environments/production/dns.tf
@@ -29,3 +29,19 @@ resource "aws_route53_record" "apex_aaaa" {
 
   allow_overwrite = true
 }
+
+resource "aws_route53_record" "apex_txt" {
+  provider = aws.shared
+
+  zone_id = data.aws_route53_zone.this.zone_id
+  name    = var.domain_name
+  type    = "TXT"
+  ttl     = 300
+
+  records = [
+    "v=spf1 include:_spf.google.com ~all",
+    "google-site-verification=B9IZkEkZVHp4ngYNJDOpcYX_y4qrv2J3ez1SzWKSuD0",
+  ]
+
+  allow_overwrite = true
+}

--- a/terraform/environments/production/dns.tf
+++ b/terraform/environments/production/dns.tf
@@ -40,7 +40,7 @@ resource "aws_route53_record" "apex_txt" {
 
   records = [
     "v=spf1 include:_spf.google.com ~all",
-    "google-site-verification=B9IZkEkZVHp4ngYNJDOpcYX_y4qrv2J3ez1SzWKSuD0",
+    "google-site-verification=${var.google_site_verification}",
   ]
 
   allow_overwrite = true

--- a/terraform/environments/production/terraform.tfvars
+++ b/terraform/environments/production/terraform.tfvars
@@ -6,3 +6,5 @@ github_environment  = "Production"
 domain_name         = "keitaito.net"
 dns_zone_id         = "Z04741573BLIJZ9ATP45N"
 shared_dns_role_arn = "arn:aws:iam::116584140838:role/blog-prod-route53-writer"
+
+google_site_verification = "B9IZkEkZVHp4ngYNJDOpcYX_y4qrv2J3ez1SzWKSuD0"

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -29,3 +29,7 @@ variable "dns_zone_id" {
 variable "shared_dns_role_arn" {
   type = string
 }
+
+variable "google_site_verification" {
+  type = string
+}


### PR DESCRIPTION
## 概要

- apex `keitaito.net` の TXT レコードを Terraform 管理下に。
- 既存の SPF + Search Console の新しい認証トークンを格納。
- 旧ポートフォリオの認証トークンは削除(未使用のため)。
- `allow_overwrite = true` で、初回 apply 時に既存 rrset を Terraform が引き取る。

## 適用手順

```sh
cd terraform/environments/production
terraform plan
terraform apply
```

## 確認

```sh
dig +short TXT keitaito.net
```

SPF と新しい `google-site-verification=...` の 2 行が返ったら、Search Console で「確認」をクリック。