### PR TITLE
fix(blog): 最新のZenn記事を追加

### DIFF
--- a/apps/blog/src/data/articles.json
+++ b/apps/blog/src/data/articles.json
@@ -1,6 +1,14 @@
 [
   {
     "id": "1",
+    "title": "Go における AWS Lambda + API Gateway + Lambda Web Adapter の選択",
+    "url": "https://zenn.dev/kk79it/articles/go-apigw-lwa-cognito",
+    "liked_count": 5,
+    "published_at": "2026-04-26",
+    "source": "zenn"
+  },
+  {
+    "id": "2",
     "title": "ウェブサービスで手軽な通知を提供する",
     "url": "https://zenn.dev/team411/articles/webservice-notify",
     "liked_count": 2,
@@ -8,7 +16,7 @@
     "source": "zenn"
   },
   {
-    "id": "2",
+    "id": "3",
     "title": "Proxmoxの運用Tips【自宅鯖】",
     "url": "https://zenn.dev/kk79it/articles/proxmox-tutorial",
     "liked_count": 9,
@@ -16,7 +24,7 @@
     "source": "zenn"
   },
   {
-    "id": "3",
+    "id": "4",
     "title": "TeXファイル内に直接gnuplotを書く",
     "url": "https://qiita.com/keitaitonet/items/6d54a28ef2a48fb15b9f",
     "liked_count": 2,
@@ -24,19 +32,11 @@
     "source": "qiita"
   },
   {
-    "id": "4",
+    "id": "5",
     "title": "少し頑張る理数系LaTeX環境構築 (Dev Container)",
     "url": "https://zenn.dev/team411/articles/latex-install-advanced",
     "liked_count": 18,
     "published_at": "2024-03-29",
-    "source": "zenn"
-  },
-  {
-    "id": "5",
-    "title": "調布祭にモバイルオーダーを導入した話",
-    "url": "https://zenn.dev/team411/articles/team411-mobile-order",
-    "liked_count": 7,
-    "published_at": "2023-12-16",
     "source": "zenn"
   }
 ]


### PR DESCRIPTION
## 変更内容

- ポートフォリオの記事一覧に最新のZenn記事を追加
- 最新5件の表示を維持するため、最も古い記事を一覧から削除
- JSON内のIDを表示順に `1`〜`5` へ振り直し

## 背景

現在のAstroサイトは、ビルド時にZennから記事を取得せず、リポジトリ内のJSONを記事一覧として読み込んでいます。そのため、新しい記事を公開してサイトを再ビルドしても、JSONを更新しない限り記事一覧には反映されません。

## 影響

Articlesセクションの先頭に「Go における AWS Lambda + API Gateway + Lambda Web Adapter の選択」が表示されます。記事一覧はこれまでどおり5件です。

## 確認内容

- `pnpm format:check`
- `pnpm --filter blog check`
- `pnpm --filter blog build`
- 生成されたHTMLに新しい記事が含まれ、入れ替え対象の最古の記事が含まれないことを確認